### PR TITLE
Update 2025  how_to_apply.html

### DIFF
--- a/how_to_apply.html
+++ b/how_to_apply.html
@@ -161,8 +161,8 @@
             <h2 class="rvt-items-center rvt-text-bold">The Datawiz-IN Scholars Program is collaborating with <a href="https://stem.indiana.edu/index.html">IU-MSI</a> STEM Summer Scholars Institute!</h2><br/>
             <h2 style="font-size: 18px;">
               <strong>Program Dates:</strong><br>
-              <span style="font-size: 17px; display: block;">Jun 3rd – July 27th, 2024 (on-campus)</span>
-              <span style="font-size: 17px; display: block;">July 28th - Aug 2nd, 2024 (some online sessions)</span>
+              <span style="font-size: 17px; display: block;">Jun 2nd – Aug 1st, 2025 (on-campus)</span>
+              <span style="font-size: 17px; display: block;">Aug 2nd - Aug 8th, 2025 (some online sessions)</span>
             </h2>
             <p class="rvt-ts-20 rvt-color-black-500">To be considered for the planned face to face 2024 Datawiz-IN Scholars Program, a completed application, and supporting documents must be submitted to the Indiana University Graduate School by March 15, 2024. Early applicants will receive priority consideration.</p>
         </div>


### PR DESCRIPTION
Updated the program dates for the Datawiz-IN Scholars Program to:
- On-campus: June 2nd – August 1st, 2025
- Online sessions: August 2nd – August 8th, 2025

